### PR TITLE
Addition of elastic net cox regression 

### DIFF
--- a/relative_importance/05-cox_lasso.R
+++ b/relative_importance/05-cox_lasso.R
@@ -1,4 +1,4 @@
-# Author: Run Jin, Adam Kraya
+# Author: Adam Kraya, Run Jin
 # Compare different modeling methods
 suppressPackageStartupMessages({
   library("optparse")

--- a/relative_importance/05-cox_lasso.R
+++ b/relative_importance/05-cox_lasso.R
@@ -1,0 +1,152 @@
+# Author: Run Jin, Adam Kraya
+# Compare different modeling methods
+suppressPackageStartupMessages({
+  library("optparse")
+  library("tidyverse")
+  library("DescTools")
+  library("survival")
+  library("glmnet")
+  library("rjson")
+})
+
+#### Parse command line options ------------------------------------------------
+option_list <- list(
+  make_option(c("-l","--cg_interest"),type="character",
+              help="comma separated list of cancer groups of interest"))
+opt <- parse_args(OptionParser(option_list=option_list,add_help_option = FALSE))
+cg_list <-unlist(strsplit(opt$cg_interest,","))
+
+#### Define Directories --------------------------------------------------------
+root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
+analysis_dir <- file.path(root_dir, "relative_importance")
+meta_combined_input_dir <- file.path(analysis_dir, "results", "expression_sub")
+results_dir <- file.path(analysis_dir, "results", "model_method_comparison")
+
+if(!dir.exists(results_dir)){
+  dir.create(results_dir)
+}
+
+plots_dir <- file.path(analysis_dir, "plots", "model_method_comparison")
+if(!dir.exists(plots_dir)){
+  dir.create(plots_dir)
+}
+
+for (i in 1:length(cg_list)){
+  # find the cancer group of interest 
+  x <- cg_list[i]
+  
+  # meta data directory
+  meta_combined <- readr::read_tsv(file.path(meta_combined_input_dir, 
+                                             paste0("meta_exp_combined_data_in_", x, ".tsv")))
+  
+  # get the gene variables 
+  gene_variables <- meta_combined[, 7:37] %>% colnames()
+  if(x == "LGG"){
+    
+    # model for all gene varialbes 
+    total.formula <- paste0("Surv(PFS_days, PFS_status_recode)", " ~ ",
+                            paste0(gene_variables, collapse = " + "),
+                            sep = "")
+    
+    # make the combined data compatible with the analysis 
+    combined_data_sub <- meta_combined %>% 
+      dplyr::select(-c("Kids_First_Participant_ID", "OS_status",
+                       "OS_status_recode", "OS_days", "PFS_status")) %>% 
+      dplyr::filter(!is.na(PFS_days)) %>%
+      tibble::column_to_rownames("Kids_First_Biospecimen_ID")
+    
+  } else {
+    
+    # model for all gene variables 
+    total.formula <- paste0("Surv(OS_days, OS_status_recode)", " ~ ",
+                            paste0(gene_variables, collapse = " + "),
+                            sep = "")
+    
+    # make the combined data compatible with the analysis 
+    combined_data_sub <- meta_combined %>% 
+      dplyr::select(-c("Kids_First_Participant_ID", "PFS_status",
+                       "PFS_status_recode", "PFS_days", "OS_status")) %>% 
+      dplyr::filter(!is.na(OS_days)) %>%
+      tibble::column_to_rownames("Kids_First_Biospecimen_ID")
+  }
+
+  
+  # generate another matrix with status and time and extract time and status as vector
+  if(x == "LGG"){
+    time_status_matrix <- combined_data_sub %>% dplyr::select("PFS_days", "PFS_status_recode") %>%
+      dplyr::rename(time = PFS_days,
+                    status = PFS_status_recode)
+  } else {
+    time_status_matrix <- combined_data_sub %>% dplyr::select("OS_days", "OS_status_recode") %>%
+      dplyr::rename(time = OS_days,
+                    status = OS_status_recode)
+  }
+  # find the time and status
+  time <- time_status_matrix$time
+  status <- time_status_matrix$status
+  opt.param.lamda1se = list()
+  opt.param.lamda_min = list()
+  k=1
+  
+  if(ncol(combined_data_sub)>=2){
+    # run elastic net cox regression, searching for optimal combination of alphas and lambdas
+    alphas = seq(from = 0, to = 1, by = 0.05)
+    opt.param.lamda_min = sapply(alphas, function(x){
+      coxlasso_cv_model <- cv.glmnet(x = as.matrix(combined_data_sub[,gene_variables]),
+                                     y = survival::Surv(time, status),
+                                     family = 'cox',
+                                     type.measure = 'deviance',
+                                     alpha = x)
+
+      c('lamda.min' = coxlasso_cv_model$lambda.min, 'partial.likelihood.lmin' = max(coxlasso_cv_model$cvm))})
+    
+    opt.param.lamda1se = sapply(alphas, function(x){
+      coxlasso_cv_model <- cv.glmnet(x = as.matrix(combined_data_sub[,gene_variables]),
+                                     y = survival::Surv(time, status),
+                                     family = 'cox',
+                                     type.measure = 'deviance',
+                                     alpha = x)
+
+      c( 'lamda.1se' = coxlasso_cv_model$lambda.1se, 'partial.likelihood.1se' = min(coxlasso_cv_model$cvm))})
+    
+    opt.param.lamda_min = as.data.table(t(opt.param.lamda_min))
+    opt.param.lamda1se = as.data.table(t(opt.param.lamda1se))
+    
+    # Find maximum partial likelihood by lambda.min and lambda.1se methods
+    ind.lambda.min = which.max(opt.param.lamda_min$partial.likelihood.lmin)
+    ind.lambda1se = which.max(opt.param.lamda1se$partial.likelihood.1se)
+    
+    alpha.min = alphas[ind.lambda.min]
+    alpha.1se = alphas[ind.lambda1se]
+    
+    
+    ## IMPORTANT: This can be removed and included in the 05-model_compare.R and fed into pec
+    opt.model.min = glmnet(x = as.matrix(combined_data_sub[,gene_variables]),
+                           y = survival::Surv(time, status),
+                           family = 'cox',
+                           type.measure = 'deviance',
+                           alpha = alpha.min,
+                           lambda = opt.param.lamda_min$lamda.min[ind.lambda.min])
+    
+    opt.model.1se = glmnet(x = as.matrix(combined_data_sub[,gene_variables]),
+                           y = survival::Surv(time, status),
+                           family = 'cox',
+                           type.measure = 'deviance',
+                           alpha = alpha.1se,
+                           lambda = opt.param.lamda1se$lamda.1se[ind.lambda1se])
+
+    
+    ## Make json of optimal params
+    optimal.params = sprintf('{"lambda.min": "%s", 
+                          "alpha.min": "%s", 
+                          "lambda.1se": "%s",
+                          "alpha.1se": %s}', 
+                          opt.param.lamda_min$lamda.min[ind.lambda.min], 
+                          alpha.min, 
+                          opt.param.lamda1se$lamda.1se[ind.lambda1se],
+                          alpha.1se)
+    
+    write(optimal.params, file.path(results_dir, "coxlasso_params.json"))
+
+  }
+}


### PR DESCRIPTION
Brief description: 
Addition of a self-contained elastic net cox regression survival analysis. 
Searches across optimal values of alpha and lambda hyperparameters, returns the model with the highest partial likelihood, then takes the selected variables for modeling in traditional cox PH. 

@runjin326 - feel free to edit to match your coding style as well as functionality to write out the forest plots. 

An integration test has been performed on HGG as an example dataset. 